### PR TITLE
Fixed inverted volume up/down labels

### DIFF
--- a/smartapps/ady624/webcore.src/webcore.groovy
+++ b/smartapps/ady624/webcore.src/webcore.groovy
@@ -3699,8 +3699,8 @@ Map getChildCommands(){
 	take				: [ (sN): "Take a picture",																					],
 	unlock				: [ (sN): "Unlock",		(sI): 'unlock-alt',							(sA): "lock",				(sV): "unlocked",					],
 	unmute				: [ (sN): "Unmute",		(sI): 'volume-up',								(sA): "mute",				(sV): "unmuted",					],
-	volumeDown			: [ (sN): "Raise volume",																					],
-	volumeUp			: [ (sN): "Lower volume",																					],
+	volumeDown			: [ (sN): "Lower volume",																					],
+	volumeUp			: [ (sN): "Raise volume",																					],
 
 // these are device virtual commands
 	doubleTap			: [ (sN): "Double Tap",			(sD): "Double tap button {0}",			(sA): "doubleTapped",			(sP):[[(sN): "Button #", (sT): sINT]]	],


### PR DESCRIPTION
A user of the WebCore for hubitat was asking me to fix my code, claiming there was an error in my volume control.  After many hours of tracing this back, and working through failures to install this on hubitat, I did a source code review and found the labels are reversed in WebCore.  This is only for Hubitat, I have no idea if such a change is needed anywhere else.